### PR TITLE
Changed to oefenweb.locales

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
   - chmod +x ${PWD}/tests/test.sh
 
-  # Run tests. (TODO: Remove test_idempotence if it works with tersmitten.locales role)
+  # Run tests. (TODO: Remove test_idempotence if it works with oefenweb.locales role)
   - test_idempotence=false ${PWD}/tests/test.sh
 
 notifications:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,4 +22,4 @@ galaxy_info:
     - server
 
 dependencies:
-  - { role: tersmitten.locales }
+  - { role: oefenweb.locales }

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- src: tersmitten.locales
+- src: oefenweb.locales

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,6 +8,6 @@
 
   tasks:
     - include_role:
-        name: tersmitten.locales
+        name: oefenweb.locales
     - include_role:
         name: role_under_test


### PR DESCRIPTION
because this should be the final name. see https://github.com/Oefenweb/ansible-locales/issues/11